### PR TITLE
Improve method of passing parameters to clickhouse

### DIFF
--- a/src/Octonica.ClickHouseClient/Types/Date32TypeInfo.NetCoreApp3.1.cs
+++ b/src/Octonica.ClickHouseClient/Types/Date32TypeInfo.NetCoreApp3.1.cs
@@ -21,6 +21,8 @@ using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 
 namespace Octonica.ClickHouseClient.Types
 {
@@ -37,6 +39,24 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
 
             return new Date32Writer(columnName, ComplexTypeName, (IReadOnlyList<DateTime>)rows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+            int days;
+
+            if (value is DateTime dateTimeValue)
+                days = dateTimeValue == default ? MinValue : (int)(dateTimeValue - DateTime.UnixEpoch).TotalDays;
+            else
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
+            
+            if (days < MinValue || days > MaxValue)
+                throw new OverflowException("The value must be in range [1925-01-01, 2283-11-11].");
+
+            queryStringBuilder.Append(days.ToString(CultureInfo.InvariantCulture));
         }
 
         partial class Date32Reader : StructureReaderBase<int, DateTime>

--- a/src/Octonica.ClickHouseClient/Types/DateTypeInfo.NetCoreApp3.1.cs
+++ b/src/Octonica.ClickHouseClient/Types/DateTypeInfo.NetCoreApp3.1.cs
@@ -21,6 +21,8 @@ using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 
 namespace Octonica.ClickHouseClient.Types
 {
@@ -32,6 +34,25 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
 
             return new DateWriter(columnName, ComplexTypeName, (IReadOnlyList<DateTime>)rows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+            DateTime dateTimeValue = value switch
+            {
+                DateTime theValue => theValue,
+                _ => throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\"."),
+            };
+            
+            var days = dateTimeValue == default ? 0 : (dateTimeValue - DateTime.UnixEpoch).TotalDays;
+            
+            if (days < 0 || days > ushort.MaxValue)
+                throw new OverflowException("The value must be in range [1970-01-01, 2149-06-06].");
+
+            queryStringBuilder.Append(days.ToString(CultureInfo.InvariantCulture));
         }
 
         public override Type GetFieldType()

--- a/src/Octonica.ClickHouseClient/Types/Enum8TypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/Enum8TypeInfo.cs
@@ -17,6 +17,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 
@@ -60,6 +62,27 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{TypeName}\".");
 
             return new Int8TypeInfo.Int8Writer(columnName, ComplexTypeName, (IReadOnlyList<sbyte>)rows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            // TODO: ClickHouseDbType.Enum is not supported in DefaultTypeInfoProvider.GetTypeInfo
+            
+            if (_enumMap == null)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotFullySpecified, "The list of items is not specified.");
+            
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+            sbyte outputValue = value switch
+            {
+                string theValue => _enumMap.TryGetValue(theValue, out var tmp) ? tmp :
+                    throw new InvalidCastException($"The value \"{theValue}\" can't be converted to {ComplexTypeName}."),
+                sbyte theValue => theValue,
+                _ => throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\"."),
+            };
+
+            queryStringBuilder.Append(outputValue.ToString(CultureInfo.InvariantCulture));
         }
 
         protected override bool TryParse(ReadOnlySpan<char> text, out sbyte value)

--- a/src/Octonica.ClickHouseClient/Types/EnumTypeInfoBase.cs
+++ b/src/Octonica.ClickHouseClient/Types/EnumTypeInfoBase.cs
@@ -28,7 +28,7 @@ namespace Octonica.ClickHouseClient.Types
     internal abstract class EnumTypeInfoBase<TValue> : IClickHouseColumnTypeInfo
         where TValue : struct
     {
-        private readonly Dictionary<string, TValue>? _enumMap;
+        protected readonly Dictionary<string, TValue>? _enumMap;
         private readonly Dictionary<TValue, string>? _reversedEnumMap;
         private readonly List<string>? _mapOrder;
 
@@ -123,6 +123,8 @@ namespace Octonica.ClickHouseClient.Types
 
             return CreateInternalColumnWriter(columnName, rows);
         }
+
+        public abstract void FormatValue(StringBuilder queryStringBuilder, object? value);
 
         public IClickHouseColumnTypeInfo GetDetailedTypeInfo(List<ReadOnlyMemory<char>> options, IClickHouseTypeInfoProvider typeInfoProvider)
         {

--- a/src/Octonica.ClickHouseClient/Types/Float32TypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/Float32TypeInfo.cs
@@ -18,6 +18,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 
@@ -46,6 +48,21 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
 
             return new Float32Writer(columnName, ComplexTypeName, (IReadOnlyList<float>)rows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+
+            float outputValue = value switch
+            {
+                float theValue => theValue,
+                _ => throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\"."),
+            };
+
+            queryStringBuilder.Append(outputValue.ToString(CultureInfo.InvariantCulture)); // .Append('\'')
         }
 
         public override Type GetFieldType()

--- a/src/Octonica.ClickHouseClient/Types/Float64TypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/Float64TypeInfo.cs
@@ -18,6 +18,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 using Octonica.ClickHouseClient.Utils;
@@ -52,6 +54,21 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
 
             return new Float64Writer(columnName, ComplexTypeName, doubleRows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+            double outputValue = value switch
+            {
+                double theValue => theValue,
+                float theValue => theValue,
+                _ => throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\"."),
+            };
+
+            queryStringBuilder.Append('\'').Append(outputValue.ToString(CultureInfo.InvariantCulture)).Append('\'');
         }
 
         public override Type GetFieldType()

--- a/src/Octonica.ClickHouseClient/Types/IClickHouseColumnTypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/IClickHouseColumnTypeInfo.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Octonica.ClickHouseClient.Protocol;
 
 namespace Octonica.ClickHouseClient.Types
@@ -57,5 +58,12 @@ namespace Octonica.ClickHouseClient.Types
         /// <param name="typeInfoProvider">The type provider that can be used to get other types.</param>
         /// <returns>The <see cref="IClickHouseColumnTypeInfo"/> with the same <see cref="IClickHouseTypeInfo.TypeName"/> as this type and with the specified list of type arguments</returns>
         IClickHouseColumnTypeInfo GetDetailedTypeInfo(List<ReadOnlyMemory<char>> options, IClickHouseTypeInfoProvider typeInfoProvider);
+
+        /// <summary>
+        /// Appends textual representation of <paramref name="value"/> as ClickHouse SQL literal into <paramref name="queryStringBuilder"/>.
+        /// </summary>
+        /// <param name="queryStringBuilder">Destination string builder</param>
+        /// <param name="value">Value (or null) to be formatted. Value is of compatible type but not necessarily of exact type.</param>
+        void FormatValue(StringBuilder queryStringBuilder, object? value);
     }
 }

--- a/src/Octonica.ClickHouseClient/Types/Int16TypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/Int16TypeInfo.cs
@@ -18,6 +18,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 using Octonica.ClickHouseClient.Utils;
@@ -55,6 +57,25 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
             
             return new Int16Writer(columnName, ComplexTypeName, shortRows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+            short outputValue;
+            
+            if (value is short ushortValue)
+                outputValue = ushortValue;
+            else if (value is sbyte sbyteValue)
+                outputValue = sbyteValue;
+            else if (value is byte byteValue)
+                outputValue = byteValue;
+            else
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
+            
+            queryStringBuilder.Append(outputValue.ToString(CultureInfo.InvariantCulture));
         }
 
         public override Type GetFieldType()

--- a/src/Octonica.ClickHouseClient/Types/Int32TypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/Int32TypeInfo.cs
@@ -18,6 +18,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 using Octonica.ClickHouseClient.Utils;
@@ -59,6 +61,29 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
             
             return new Int32Writer(columnName, ComplexTypeName, intRows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+            int outputValue;
+
+            if (value is int intValue)
+                outputValue = intValue;
+            else if (value is short shortValue)
+                outputValue = shortValue;
+            else if (value is ushort ushortValue)
+                outputValue = ushortValue;
+            else if (value is sbyte sbyteValue)
+                outputValue = sbyteValue;
+            else if (value is byte byteValue)
+                outputValue = byteValue;
+            else
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
+            
+            queryStringBuilder.Append(outputValue.ToString(CultureInfo.InvariantCulture));
         }
 
         public override Type GetFieldType()

--- a/src/Octonica.ClickHouseClient/Types/Int64TypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/Int64TypeInfo.cs
@@ -18,6 +18,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 using Octonica.ClickHouseClient.Utils;
@@ -63,6 +65,25 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{type}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
             
             return new Int64Writer(columnName, ComplexTypeName, longRows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+            long outputValue = value switch
+            {
+                long theValue => theValue,
+                int theValue => theValue,
+                short theValue => theValue,
+                ushort theValue => theValue,
+                sbyte theValue => theValue,
+                byte theValue => theValue,
+                _ => throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\"."),
+            };
+            
+            queryStringBuilder.Append(outputValue.ToString(CultureInfo.InvariantCulture));
         }
 
         public override Type GetFieldType()

--- a/src/Octonica.ClickHouseClient/Types/Int8TypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/Int8TypeInfo.cs
@@ -17,6 +17,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 
@@ -45,6 +47,21 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
 
             return new Int8Writer(columnName, ComplexTypeName, (IReadOnlyList<sbyte>)rows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+            sbyte outputValue;
+
+            if (value is sbyte sbyteValue)
+                outputValue = sbyteValue;
+            else
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
+            
+            queryStringBuilder.Append(outputValue.ToString(CultureInfo.InvariantCulture));
         }
 
         public override Type GetFieldType()

--- a/src/Octonica.ClickHouseClient/Types/LowCardinalityTypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/LowCardinalityTypeInfo.cs
@@ -19,6 +19,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 using Octonica.ClickHouseClient.Utils;
@@ -83,6 +84,17 @@ namespace Octonica.ClickHouseClient.Types
 
             // Writing values as is. Let the database do de-duplication
             return _baseType.CreateColumnWriter(columnName, rows, columnSettings);
+        }
+
+        public void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (_baseType == null)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotFullySpecified, $"The type \"{ComplexTypeName}\" is not fully specified.");
+            
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+            _baseType.FormatValue(queryStringBuilder, value);
         }
 
         public IClickHouseColumnTypeInfo GetDetailedTypeInfo(List<ReadOnlyMemory<char>> options, IClickHouseTypeInfoProvider typeInfoProvider)

--- a/src/Octonica.ClickHouseClient/Types/NothingTypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/NothingTypeInfo.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 
@@ -44,6 +45,11 @@ namespace Octonica.ClickHouseClient.Types
         public IClickHouseColumnWriter CreateColumnWriter<T>(string columnName, IReadOnlyList<T> rows, ClickHouseColumnSettings? columnSettings)
         {
             return new NothingColumnWriter(columnName, ComplexTypeName, rows.Count);
+        }
+
+        public void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            throw new ClickHouseException(ClickHouseErrorCodes.InternalError, $"The ClickHouse type \"{ComplexTypeName}\" does not have any values");
         }
 
         IClickHouseColumnTypeInfo IClickHouseColumnTypeInfo.GetDetailedTypeInfo(List<ReadOnlyMemory<char>> options, IClickHouseTypeInfoProvider typeInfoProvider)

--- a/src/Octonica.ClickHouseClient/Types/NullableTypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/NullableTypeInfo.cs
@@ -19,6 +19,7 @@ using System;
 using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 using Octonica.ClickHouseClient.Utils;
@@ -71,6 +72,17 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotFullySpecified, $"The type \"{ComplexTypeName}\" is not fully specified.");
 
             return new NullableColumnWriter<T>(columnName, rows, columnSettings, UnderlyingType);
+        }
+
+        public void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (UnderlyingType == null)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotFullySpecified, $"The type \"{ComplexTypeName}\" is not fully specified.");
+            
+            if (value == null || value is DBNull)
+                queryStringBuilder.Append("null");
+            else
+                UnderlyingType.FormatValue(queryStringBuilder, value);
         }
 
         public IClickHouseColumnTypeInfo GetDetailedTypeInfo(List<ReadOnlyMemory<char>> options, IClickHouseTypeInfoProvider typeInfoProvider)

--- a/src/Octonica.ClickHouseClient/Types/SimpleTypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/SimpleTypeInfo.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 
@@ -62,6 +63,9 @@ namespace Octonica.ClickHouseClient.Types
 
         /// <inheritdoc/>
         public abstract ClickHouseDbType GetDbType();
+
+        /// <inheritdoc/>
+        public abstract void FormatValue(StringBuilder queryStringBuilder, object? value);
 
         /// <summary>
         /// Gets the generic arguments at the specified position.

--- a/src/Octonica.ClickHouseClient/Types/StringTypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/StringTypeInfo.cs
@@ -76,6 +76,63 @@ namespace Octonica.ClickHouseClient.Types
 
             throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
         }
+        
+        const string HexDigits = "0123456789ABCDEF";
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+            else if (value is string stringValue)
+                FormatCharString(stringValue);
+            else if (value is char[] charArrValue)
+                FormatCharString(charArrValue);
+            else if (value is ReadOnlyMemory<char> charRoMemValue)
+                FormatCharString(charRoMemValue.Span);
+            else if (value is Memory<char> charMemValue)
+                FormatCharString(charMemValue.Span);
+            else if (value is byte[] byteArrValue)
+                FormatByteString(byteArrValue);
+            else if (value is ReadOnlyMemory<byte> byteRoMemValue)
+                FormatByteString(byteRoMemValue.Span);
+            else if (value is Memory<byte> byteMemValue)
+                FormatByteString(byteMemValue.Span);
+            else
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
+
+            void FormatCharString(ReadOnlySpan<char> data)
+            {
+                queryStringBuilder.Append('\'');
+                foreach (var charValue in data)
+                {
+                    switch (charValue)
+                    {
+                        case '\\':
+                            queryStringBuilder.Append("\\\\");
+                            break;
+                        case '\'':
+                            queryStringBuilder.Append("''");
+                            break;
+                        default:
+                            queryStringBuilder.Append(charValue);
+                            break;
+                    }
+                }
+                queryStringBuilder.Append('\'');
+            }
+            
+            void FormatByteString(ReadOnlySpan<byte> data)
+            {
+                queryStringBuilder.Append('\'');
+                foreach (var byteValue in data)
+                {
+                    queryStringBuilder.Append("\\x");
+                    queryStringBuilder.Append(HexDigits[byteValue >> 4]);
+                    queryStringBuilder.Append(HexDigits[byteValue & 0xF]);
+                }
+                queryStringBuilder.Append('\'');
+            }
+        }
 
         public override Type GetFieldType()
         {

--- a/src/Octonica.ClickHouseClient/Types/UInt16TypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/UInt16TypeInfo.cs
@@ -18,6 +18,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 using Octonica.ClickHouseClient.Utils;
@@ -53,6 +55,24 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
 
             return new UInt16Writer(columnName, ComplexTypeName, ushortRows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+
+            ushort outputValue;
+            
+            if (value is ushort ushortValue)
+                outputValue = ushortValue;
+            else if (value is byte byteValue)
+                outputValue = byteValue;
+            else
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
+            
+            queryStringBuilder.Append(outputValue.ToString(CultureInfo.InvariantCulture));
         }
 
         public override Type GetFieldType()

--- a/src/Octonica.ClickHouseClient/Types/UInt32TypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/UInt32TypeInfo.cs
@@ -18,6 +18,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 using Octonica.ClickHouseClient.Utils;
@@ -56,6 +58,25 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
             
             return new UInt32Writer(columnName, ComplexTypeName, uintRows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+            uint outputValue;
+            
+            if (value is uint uintValue)
+                outputValue = uintValue;
+            else if (value is ushort ushortValue)
+                outputValue = ushortValue;
+            else if (value is byte byteValue)
+                outputValue = byteValue;
+            else
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
+
+            queryStringBuilder.Append(outputValue.ToString(CultureInfo.InvariantCulture));
         }
 
         public override Type GetFieldType()

--- a/src/Octonica.ClickHouseClient/Types/UInt64TypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/UInt64TypeInfo.cs
@@ -18,6 +18,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 using Octonica.ClickHouseClient.Utils;
@@ -58,6 +60,27 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
 
             return new UInt64Writer(columnName, ComplexTypeName, ulongRows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+            ulong outputValue;
+            
+            if (value is ulong ulongValue)
+                outputValue = ulongValue;
+            else if (value is uint uintValue)
+                outputValue = uintValue;
+            else if (value is ushort ushortValue)
+                outputValue = ushortValue;
+            else if (value is byte byteValue)
+                outputValue = byteValue;
+            else
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
+            
+            queryStringBuilder.Append(outputValue.ToString(CultureInfo.InvariantCulture));
         }
 
         public override Type GetFieldType()

--- a/src/Octonica.ClickHouseClient/Types/UInt8TypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/UInt8TypeInfo.cs
@@ -17,6 +17,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 using Octonica.ClickHouseClient.Utils;
@@ -51,6 +53,23 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
 
             return new UInt8Writer(columnName, ComplexTypeName, byteRows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+
+            byte outputValue;
+
+            if (value is byte byteValue)
+                outputValue = byteValue;
+            else if (value is bool boolValue)
+                outputValue = boolValue ? (byte)1 : (byte)0;
+            else
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
+            
+            queryStringBuilder.Append(outputValue.ToString(CultureInfo.InvariantCulture));
         }
 
         public override Type GetFieldType()

--- a/src/Octonica.ClickHouseClient/Types/UuidTypeInfo.cs
+++ b/src/Octonica.ClickHouseClient/Types/UuidTypeInfo.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 using Octonica.ClickHouseClient.Exceptions;
 using Octonica.ClickHouseClient.Protocol;
 
@@ -48,6 +49,16 @@ namespace Octonica.ClickHouseClient.Types
                 throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{typeof(T)}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
 
             return new UuidWriter(columnName, ComplexTypeName, (IReadOnlyList<Guid>)rows);
+        }
+
+        public override void FormatValue(StringBuilder queryStringBuilder, object? value)
+        {
+            if (value == null || value is DBNull)
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The ClickHouse type \"{ComplexTypeName}\" does not allow null values");
+            else if (value is Guid uuidValue)
+                queryStringBuilder.Append("'").Append(uuidValue).Append("'");
+            else
+                throw new ClickHouseException(ClickHouseErrorCodes.TypeNotSupported, $"The type \"{value.GetType()}\" can't be converted to the ClickHouse type \"{ComplexTypeName}\".");
         }
 
         public override Type GetFieldType()


### PR DESCRIPTION
Old implementation was to create "provided table" with one column per parameter and one row;
parameter substituion was done as subquery to "provided table".

This lets reuse the same logic for column writers and parameters.

Unfortunately, old strategy had some flaws that stem from ClickHouse's interpretation of
scalar subqueries (like `(select {column} from {provided table})`):

*   Scalar subqueries always have type `Nullable(T)` where `T` is type of `{column}`.
    In some contexts only non-nullable expressions are allowed. E.g. this query:

    `select ... from ... limit @N offset @M`

    throws error:

    `Illegal type Nullable(Int32) of LIMIT expression, must be numeric type`

*   Scalar subqueries are not constant expressions
    In some contexts only constant expressions are allowed. E.g. this query:

    `insert into {table} ({column}) values (@V)`

    throws error:

    `Element of set in IN, VALUES or LIMIT or aggregate function parameter is not a constant expression (result column not found)`

*   External tables are only available for `SELECT` queries.
    E.g. these queries:

    `alter table {table} delete where {column}=@V`
    `alter table {table} update {column}=@V1 where {column}=@V2`
    throw error:
    
    `Table default._ce4fd69c9d284eacbe7a396f1b5cc35a doesn't exist`

New implementation strategy is to interpolate parameter values in query string.
Parameter references such as `@p` or `{p:type}` are replaced with `cast({Value} as {Type1})` or `cast(cast({Value} as {Type1}) as {Type2})` where:
* `{Value}` is an expression that corresponds to parameter's value (usually just a literal but sometimes is more complex)
* `{Type1}` as a ClickHouse type inferred from `DbParameter.DbType` and/or `DbParameter.Value` using already existing logic
* `{Type2}` is a ClickHouse type that was specified in parameter token: `{p:Type}`

This double casting preserves existing semantics:
* `DbParameter.DbType` and/or `DbParameter.Value` determine ColumnWriter and the type of a column in parameters table
* Type in parameter token specifies the type to which inner value should be cast.

If it were not for backwards compatibility I would prefer to remove this double casting and use type from parameter token to determine which type of value to format.

One difficulty with this strategy is that some ClickHouse data types can not be fully represented as literals or as strings which requires some workarounds.
E.g.:
*   Floating-point values with exponent `∈(-∞,-100] ∪ [100, +∞)` (e.g., `1e-100`) are not supported as literals and require casting from strings
*   Decimal values of types `DecimalN(P, S)` are limited to ±10^(M-S) (where M=9, 18, 38, 76 for N=32, 64, 128, 256) when converting from string
    but are limited to larger range ±2^(N-1) in binary representation. This can be worked around by using reinterpret_cast from UInt{N} to Decimal{N}.
*   Number literals greater than 2^64 are parsed as Float64. This requires casting such values from strings.