### PR TITLE
DbDataReader returns DateTimeKind.Unspecified for columns of types Date and Date32 for all versions of .NET

### DIFF
--- a/src/Octonica.ClickHouseClient.Tests/ClickHouseDataReaderTests.cs
+++ b/src/Octonica.ClickHouseClient.Tests/ClickHouseDataReaderTests.cs
@@ -421,5 +421,49 @@ namespace Octonica.ClickHouseClient.Tests
             Assert.Equal(expectedCount, count);
             Assert.True(selectedRows >= expectedCount);
         }
+
+        [Fact]
+        public async Task DateTimeKindForDate()
+        {
+            await using var cn = await OpenConnectionAsync();
+
+            await using var cmd = cn.CreateCommand();
+            cmd.CommandText = "select cast('2022-01-01' as Date)";
+
+            await using var reader = await cmd.ExecuteReaderAsync(CancellationToken.None);
+            Assert.True(await reader.ReadAsync(CancellationToken.None));
+            var value = reader.GetDateTime(0);
+            Assert.False(await reader.ReadAsync());
+
+            Assert.Equal(2022, value.Year);
+            Assert.Equal(1, value.Month);
+            Assert.Equal(1, value.Day);
+            Assert.Equal(0, value.Hour);
+            Assert.Equal(0, value.Minute);
+            Assert.Equal(0, value.Second);
+            Assert.Equal(DateTimeKind.Unspecified, value.Kind);
+        }
+
+        [Fact]
+        public async Task DateTimeKindForDate32()
+        {
+            await using var cn = await OpenConnectionAsync();
+
+            await using var cmd = cn.CreateCommand();
+            cmd.CommandText = "select cast('2022-01-01' as Date32)";
+
+            await using var reader = await cmd.ExecuteReaderAsync(CancellationToken.None);
+            Assert.True(await reader.ReadAsync(CancellationToken.None));
+            var value = reader.GetDateTime(0);
+            Assert.False(await reader.ReadAsync());
+
+            Assert.Equal(2022, value.Year);
+            Assert.Equal(1, value.Month);
+            Assert.Equal(1, value.Day);
+            Assert.Equal(0, value.Hour);
+            Assert.Equal(0, value.Minute);
+            Assert.Equal(0, value.Second);
+            Assert.Equal(DateTimeKind.Unspecified, value.Kind);
+        }
     }
 }

--- a/src/Octonica.ClickHouseClient/Types/Date32TableColumn.NetCoreApp3.1.cs
+++ b/src/Octonica.ClickHouseClient/Types/Date32TableColumn.NetCoreApp3.1.cs
@@ -23,13 +23,15 @@ namespace Octonica.ClickHouseClient.Types
 {
     partial class Date32TableColumn : IClickHouseTableColumn<DateTime>
     {
+        static readonly DateTime UnixEpochUnspecified = new DateTime(DateTime.UnixEpoch.Ticks, DateTimeKind.Unspecified);
+
         public DateTime GetValue(int index)
         {
             var value = _buffer.Span[index];
             if (value == DefaultValue)
                 return default;
 
-            return DateTime.UnixEpoch.AddDays(value);
+            return UnixEpochUnspecified.AddDays(value);
         }
 
         public IClickHouseTableColumn<T>? TryReinterpret<T>()

--- a/src/Octonica.ClickHouseClient/Types/DateTypeInfo.NetCoreApp3.1.cs
+++ b/src/Octonica.ClickHouseClient/Types/DateTypeInfo.NetCoreApp3.1.cs
@@ -41,6 +41,8 @@ namespace Octonica.ClickHouseClient.Types
 
         partial class DateReader : StructureReaderBase<DateTime>
         {
+            static readonly DateTime UnixEpochUnspecified = new DateTime(DateTime.UnixEpoch.Ticks, DateTimeKind.Unspecified);
+
             public DateReader(int rowCount)
                 : base(sizeof(ushort), rowCount)
             {
@@ -52,7 +54,7 @@ namespace Octonica.ClickHouseClient.Types
                 if (value == 0)
                     return default;
 
-                return DateTime.UnixEpoch.AddDays(value);
+                return UnixEpochUnspecified.AddDays(value);
             }
         }
 


### PR DESCRIPTION
DbDataReader.GetDateTime had inconsistent behaviour between .NET 5 and .NET 6:

* In .NET 6 GetDateTime returned DateTime values with DateTimeKind.Unspecified
* In .NET 5 GetDateTime returned DateTime values with DateTimeKind.Utc

.NET 6 behaviour is better because:

* It is consistent with other ADO.NET drivers (e.g., Npgsql)
* Date-only values do not correspond to time instant and should not be bound to any timezone offset