### PR TITLE
Return the correct non-generic enumerator for ClickHouseParameterCollection

### DIFF
--- a/src/Octonica.ClickHouseClient/ClickHouseParameterCollection.cs
+++ b/src/Octonica.ClickHouseClient/ClickHouseParameterCollection.cs
@@ -447,7 +447,7 @@ namespace Octonica.ClickHouseClient
         /// <inheritdoc/>
         public override IEnumerator GetEnumerator()
         {
-            return _parameters.GetEnumerator();
+            return _parameterNames.Select(n => _parameters[n]).GetEnumerator();
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
A `foreach` loop uses the non-generic ` IEnumerator GetEnumerator()`. This currently  uses `_parameters.GetEnumerator()` which returns the enumerator of the dictionary, which returns `KeyValuePair<string, ClickHouseParameter>`'s rather than `ClickHouseParameter`'s. This causes an error when using `DynamicParameters` with Dapper: https://github.com/DapperLib/Dapper/blob/ca00feeb5fafe5262166689c0bec2b80b53add4e/Dapper/DynamicParameters.cs#L194.