### PR TITLE
Fix over-allocaction for (ReadOnly)Memory<T> 

### DIFF
--- a/src/Octonica.ClickHouseClient/Utils/ICollectionList.cs
+++ b/src/Octonica.ClickHouseClient/Utils/ICollectionList.cs
@@ -1,5 +1,5 @@
 ﻿#region License Apache 2.0
-/* Copyright 2021 Octonica
+/* Copyright 2023 Octonica
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Octonica.ClickHouseClient/Utils/ICollectionList.cs
+++ b/src/Octonica.ClickHouseClient/Utils/ICollectionList.cs
@@ -1,0 +1,30 @@
+﻿#region License Apache 2.0
+/* Copyright 2021 Octonica
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace Octonica.ClickHouseClient.Utils
+{
+    internal interface ICollectionList<out T>
+    {
+        int Count { get; }
+        T this[int listIndex, int index] { get; }
+        IEnumerable<T> GetItems();
+        IEnumerable<int> GetListLengths();
+        int GetLength(int listIndex);
+    }
+}

--- a/src/Octonica.ClickHouseClient/Utils/MemoryCollectionList.cs
+++ b/src/Octonica.ClickHouseClient/Utils/MemoryCollectionList.cs
@@ -1,5 +1,5 @@
 ﻿#region License Apache 2.0
-/* Copyright 2021 Octonica
+/* Copyright 2023 Octonica
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Octonica.ClickHouseClient/Utils/MemoryCollectionList.cs
+++ b/src/Octonica.ClickHouseClient/Utils/MemoryCollectionList.cs
@@ -1,0 +1,46 @@
+﻿#region License Apache 2.0
+/* Copyright 2021 Octonica
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Octonica.ClickHouseClient.Utils
+{
+    internal sealed class MemoryCollectionList<T> : ICollectionList<T>
+    {
+        private readonly IReadOnlyList<Memory<T>> _list;
+
+        public MemoryCollectionList(IReadOnlyList<Memory<T>> list)
+            => _list = list;
+
+        public int Count => _list.Count;
+
+        public T this[int listIndex, int index]
+            => _list[listIndex].Span[index];
+
+        public IEnumerable<T> GetItems()
+            => _list.SelectMany(list => MemoryMarshal.ToEnumerable<T>(list));
+
+        public IEnumerable<int> GetListLengths()
+            => _list.Select(item => item.Length);
+
+        public int GetLength(int listIndex)
+            => _list[listIndex].Length;
+    }
+}

--- a/src/Octonica.ClickHouseClient/Utils/ReadOnlyCollectionList.cs
+++ b/src/Octonica.ClickHouseClient/Utils/ReadOnlyCollectionList.cs
@@ -1,0 +1,44 @@
+﻿#region License Apache 2.0
+/* Copyright 2021 Octonica
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Octonica.ClickHouseClient.Utils
+{
+    internal sealed class ReadOnlyCollectionList<T> : ICollectionList<T>
+    {
+        private readonly IReadOnlyList<IReadOnlyList<T>?> _list;
+
+        public ReadOnlyCollectionList(IReadOnlyList<IReadOnlyList<T>?> list)
+            => _list = list;
+
+        public int Count => _list.Count;
+
+        public T this[int listIndex, int index]
+            => _list[listIndex]![index];
+
+        public IEnumerable<T> GetItems()
+            => _list.SelectMany(list => list ?? Enumerable.Empty<T>());
+
+        public IEnumerable<int> GetListLengths()
+            => _list.Select(item => item?.Count ?? 0);
+
+        public int GetLength(int listIndex)
+            => _list[listIndex]?.Count ?? 0;
+    }
+}

--- a/src/Octonica.ClickHouseClient/Utils/ReadOnlyCollectionList.cs
+++ b/src/Octonica.ClickHouseClient/Utils/ReadOnlyCollectionList.cs
@@ -1,5 +1,5 @@
 ﻿#region License Apache 2.0
-/* Copyright 2021 Octonica
+/* Copyright 2023 Octonica
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Octonica.ClickHouseClient/Utils/ReadOnlyMemoryCollectionList.cs
+++ b/src/Octonica.ClickHouseClient/Utils/ReadOnlyMemoryCollectionList.cs
@@ -1,5 +1,5 @@
 ﻿#region License Apache 2.0
-/* Copyright 2021 Octonica
+/* Copyright 2023 Octonica
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Octonica.ClickHouseClient/Utils/ReadOnlyMemoryCollectionList.cs
+++ b/src/Octonica.ClickHouseClient/Utils/ReadOnlyMemoryCollectionList.cs
@@ -1,0 +1,46 @@
+﻿#region License Apache 2.0
+/* Copyright 2021 Octonica
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Octonica.ClickHouseClient.Utils
+{
+    internal sealed class ReadOnlyMemoryCollectionList<T> : ICollectionList<T>
+    {
+        private readonly IReadOnlyList<ReadOnlyMemory<T>> _list;
+
+        public ReadOnlyMemoryCollectionList(IReadOnlyList<ReadOnlyMemory<T>> list)
+            => _list = list;
+
+        public int Count => _list.Count;
+
+        public T this[int listIndex, int index]
+            => _list[listIndex].Span[index];
+
+        public IEnumerable<T> GetItems()
+            => _list.SelectMany(MemoryMarshal.ToEnumerable);
+
+        public IEnumerable<int> GetListLengths()
+            => _list.Select(item => item.Length);
+
+        public int GetLength(int listIndex)
+            => _list[listIndex].Length;
+    }
+}


### PR DESCRIPTION
Hi!

There is a strange memory allocation behavior on writing arrays as Memory<T>\ReadOnlyMemory<T>

| Method         | Mean     | Error   | StdDev  | Allocated  |
|--------------- |---------:|--------:|--------:|-----------:|
| Array          | 102.6 ms | 1.61 ms | 1.50 ms |  200.64 KB |
| Memory         | 101.9 ms | 1.52 ms | 1.35 ms | 1169.16 KB |
| ReadonlyMemory | 101.9 ms | 1.68 ms | 1.57 ms | 1169.83 KB |

[Benchmark code](https://github.com/alec-anikin/Octonica.ClickHouseClient/blob/memory_before/src/Octonica.ClickHouseClient.Benchmarks/InsertMemory.cs) insert the same data as array, Memory and ReadOnlyMemory.

I try to solve the issue with this PR and new code benchmarks are below

| Method         | Mean     | Error   | StdDev  | Allocated |
|--------------- |---------:|--------:|--------:|----------:|
| Array          | 101.6 ms | 1.61 ms | 1.42 ms | 202.37 KB |
| Memory         | 102.2 ms | 1.88 ms | 1.76 ms | 202.38 KB |
| ReadonlyMemory | 101.7 ms | 1.99 ms | 1.95 ms | 201.43 KB |

Thank you!
