### PR TITLE
Fixed handling of DateTime64 dates on Windows systems

### DIFF
--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    // Verwendet IntelliSense zum Ermitteln möglicher Attribute.
+    // Zeigen Sie auf vorhandene Attribute, um die zugehörigen Beschreibungen anzuzeigen.
+    // Weitere Informationen finden Sie unter https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/Octonica.ClickHouseClient/bin/Debug/net8.0/Octonica.ClickHouseClient.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        }
+
+    ]
+}

--- a/src/.vscode/tasks.json
+++ b/src/.vscode/tasks.json
@@ -1,0 +1,44 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "shell",
+      "args": [
+        "build",
+        "${workspaceFolder}/Octonica.ClickHouseClient/Octonica.ClickHouseClient.csproj"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "run",
+      "command": "dotnet",
+      "type": "shell",
+      "args": [
+        "run",
+        "${workspaceFolder}/path/to/project.csproj"
+      ],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "test",
+      "command": "dotnet",
+      "type": "shell",
+      "args": [
+        "test",
+        "${workspaceFolder}/path/to/project.csproj"
+      ],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/src/Octonica.ClickHouseClient.Tests/CityHashTests.cs
+++ b/src/Octonica.ClickHouseClient.Tests/CityHashTests.cs
@@ -63,7 +63,7 @@ namespace Octonica.ClickHouseClient.Tests
 
         void Test(int index, int offset, int len)
         {
-            var seq = new ReadOnlySequence<byte>(data, offset, len);
+            var seq = new ReadOnlySequence<byte>(data!, offset, len);
 
             UInt128 u = CityHash.CityHash128(seq);
             UInt128 v = CityHash.CityHash128WithSeed(seq, kSeed128);

--- a/src/Octonica.ClickHouseClient.Tests/Octonica.ClickHouseClient.Tests.csproj
+++ b/src/Octonica.ClickHouseClient.Tests/Octonica.ClickHouseClient.Tests.csproj
@@ -1,16 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.4" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Octonica.ClickHouseClient/ClickHouseCommand.cs
+++ b/src/Octonica.ClickHouseClient/ClickHouseCommand.cs
@@ -42,7 +42,7 @@ namespace Octonica.ClickHouseClient
         private TimeSpan? _commandTimeout;
 
         /// <summary>
-        /// Gets or sets the SQL statement to exeucute at the data source.
+        /// Gets or sets the SQL statement to execute at the data source.
         /// </summary>
         [AllowNull]
         public override string CommandText

--- a/src/Octonica.ClickHouseClient/Octonica.ClickHouseClient.csproj
+++ b/src/Octonica.ClickHouseClient/Octonica.ClickHouseClient.csproj
@@ -23,7 +23,7 @@
     <PackageTags>ClickHouse</PackageTags>
     <RepositoryUrl>https://github.com/Octonica/ClickHouseClient.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>Octonica.ClickHouseClient</Title>
     <Version>3.1.1</Version>
   </PropertyGroup>

--- a/src/Octonica.ClickHouseClient/Octonica.ClickHouseClient.csproj
+++ b/src/Octonica.ClickHouseClient/Octonica.ClickHouseClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <Version Condition="'$(ClickHouseClientVersion)' != ''">$(ClickHouseClientVersion)</Version>
-    <Version Condition="'$(Version)' == ''">2.2.8</Version>
+    <Version Condition="'$(Version)' == ''">3.1.1</Version>
     <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">$(Version).0</AssemblyVersion>
     <Version Condition="'$(ClickHouseClientVersionSuffix)' != ''">$(Version)$(ClickHouseClientVersionSuffix)</Version>
 
@@ -23,11 +23,17 @@
     <PackageTags>ClickHouse</PackageTags>
     <RepositoryUrl>https://github.com/Octonica/ClickHouseClient.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Title>Octonica.ClickHouseClient</Title>
+    <Version>3.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="K4os.Compression.LZ4" Version="1.3.6" />
-    <PackageReference Include="TimeZoneConverter" Version="6.1.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
   </ItemGroup>
-
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
+    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="72.1.0.3" />
+ </ItemGroup>
 </Project>

--- a/src/Octonica.ClickHouseClient/Octonica.ClickHouseClient.sln
+++ b/src/Octonica.ClickHouseClient/Octonica.ClickHouseClient.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octonica.ClickHouseClient", "Octonica.ClickHouseClient.csproj", "{CCF31A8F-29D3-496D-B943-7941FCF3D608}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CCF31A8F-29D3-496D-B943-7941FCF3D608}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CCF31A8F-29D3-496D-B943-7941FCF3D608}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CCF31A8F-29D3-496D-B943-7941FCF3D608}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CCF31A8F-29D3-496D-B943-7941FCF3D608}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {32491829-5C95-4CF0-995F-47BBE8051DE4}
+	EndGlobalSection
+EndGlobal

--- a/src/Octonica.ClickHouseClient/Types/DateTime64TableColumn.cs
+++ b/src/Octonica.ClickHouseClient/Types/DateTime64TableColumn.cs
@@ -16,6 +16,7 @@
 #endregion
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Octonica.ClickHouseClient.Types
 {
@@ -77,7 +78,7 @@ namespace Octonica.ClickHouseClient.Types
             TimeSpan offset;
 
             // check operating system
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Windows
                 dateTime = DateTimeOffset.FromUnixTimeMilliseconds(ticks);

--- a/src/Octonica.ClickHouseClient/Utils/TimeZoneHelper.Net6.0.cs
+++ b/src/Octonica.ClickHouseClient/Utils/TimeZoneHelper.Net6.0.cs
@@ -19,6 +19,8 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using TimeZoneConverter;
 
 namespace Octonica.ClickHouseClient.Utils
 {
@@ -27,6 +29,10 @@ namespace Octonica.ClickHouseClient.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static partial void GetTimeZoneInfoImpl(string timeZone, ref TimeZoneInfo? timeZoneInfo)
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                timeZone = TZConvert.IanaToWindows(timeZone);
+            }
             timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(timeZone);
         }
 


### PR DESCRIPTION
- Added launch files for VSCode
- Fixed handling of DateTime64 dates on Windows systems
- Convert Linux timezone to Windows timezone on Windows systems
- removed support for older .NET versions than .NET 8 (don't accept these changes, if you still want to support older .NET versions. I was simply too lazy to install the old Framework versions)
- updated XUnit and .NET Test SDK